### PR TITLE
Prevent compiler macro expansion.

### DIFF
--- a/csv.h
+++ b/csv.h
@@ -823,12 +823,12 @@ namespace io{
         struct set_to_max_on_overflow{
                 template<class T>
                 static void on_overflow(T&x){
-                        x = std::numeric_limits<T>::max();
+                        x = (std::numeric_limits<T>::max)();
                 }
                
                 template<class T>
                 static void on_underflow(T&x){
-                        x = std::numeric_limits<T>::min();
+                        x = (std::numeric_limits<T>::min)();
                 }
         };
 
@@ -957,7 +957,7 @@ namespace io{
                         while(*col != '\0'){
                                 if('0' <= *col && *col <= '9'){
                                         T y = *col - '0';
-                                        if(x > (std::numeric_limits<T>::max()-y)/10){
+                                        if(x > ((std::numeric_limits<T>::max)()-y)/10){
                                                 overflow_policy::on_overflow(x);
                                                 return;
                                         }
@@ -988,7 +988,7 @@ namespace io{
                                 while(*col != '\0'){
                                         if('0' <= *col && *col <= '9'){
                                                 T y = *col - '0';
-                                                if(x < (std::numeric_limits<T>::min()+y)/10){
+                                                if(x < ((std::numeric_limits<T>::min)()+y)/10){
                                                         overflow_policy::on_underflow(x);
                                                         return;
                                                 }


### PR DESCRIPTION
Fixes bug that caused macro expansion to override min/max from #NOMINMAX declaration in minwindef.h.
